### PR TITLE
Catalog update

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -106,6 +106,12 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
         return nestCatalogItemId(val);
     }
 
+    public SpecT catalogItemIds(List<String> ids) {
+        catalogItemIdStack.clear();
+        catalogItemIdStack.addAll(ids);
+        return self();
+    }
+
     /**
      * Adds (stacks) the catalog item id of a wrapping specification.
      * Does nothing if the value is null.
@@ -116,7 +122,7 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
      */
     @Beta
     public SpecT nestCatalogItemId(String val) {
-        if (null != val) {
+        if (null != val && (catalogItemIdStack.isEmpty() || !catalogItemIdStack.element().equals(val))) {
             catalogItemIdStack.addFirst(val);
         }
         return self();

--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -213,7 +213,7 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     }
 
     /**
-     * Get immutable list of ids of this object's catalog item and its nested catalog items.
+     * An immutable list of ids of this object's catalog item and its defining catalog items.
      * e.g. if the catalog item is defined as
      * <pre>
      *     items:
@@ -222,7 +222,7 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
      * </pre>
      * then the list will contain X, Y.
      */
-    public final List<String> getNestedCatalogItemIds() {
+    public final List<String> getCatalogItemSuperIds() {
         return ImmutableList.copyOf(catalogItemIdStack);
     }
 

--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -22,9 +22,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -65,7 +68,7 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     
     private final Class<? extends T> type;
     private String displayName;
-    private String catalogItemId;
+    private Deque<String> catalogItemIdStack = new ArrayDeque<>();
     private Set<Object> tags = MutableSet.of();
     private List<SpecParameter<?>> parameters = ImmutableList.of();
 
@@ -75,7 +78,7 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     protected AbstractBrooklynObjectSpec(Class<? extends T> type) {
         checkValidType(type);
         this.type = type;
-        this.catalogItemId = ApiObjectsFactory.get().getCatalogItemIdFromContext();
+        catalogItemId(ApiObjectsFactory.get().getCatalogItemIdFromContext());
     }
     
     @SuppressWarnings("unchecked")
@@ -99,23 +102,39 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     }
     
     public SpecT catalogItemId(String val) {
-        catalogItemId = val;
-        return self();
+        catalogItemIdStack.clear();
+        return nestCatalogItemId(val);
     }
-    // TODO in many places (callers to this method) we prefer a wrapper item ID;
-    // that is right, because the wrapper's defn will refer to the wrapped,
-    // but we might need also to collect the item ID's so that *all* can be searched.
-    // e.g. if R3 references R2 which references R1 any one of these might supply config keys 
-    // referencing resources or types in their local bundles. 
+
+    /**
+     * Adds (stacks) the catalog item id of a wrapping specification.
+     * Does nothing if the value is null.
+     *
+     * Used when we to collect nested item ID's so that *all* can be searched.
+     * e.g. if R3 references R2 which references R1 any one of these might supply config keys
+     * referencing resources or types in their local bundles.
+     */
     @Beta
-    public SpecT catalogItemIdIfNotNull(String val) {
-        if (val!=null) {
-            catalogItemId = val;
+    public SpecT nestCatalogItemId(String val) {
+        if (null != val) {
+            catalogItemIdStack.addFirst(val);
         }
         return self();
     }
 
-    
+    /**
+     * Replaces the current catalog item id with the given value only if it is not null.
+     * Otherwise has no effect.
+     */
+    @Beta
+    public SpecT catalogItemIdIfNotNull(String val) {
+        if (val!=null) {
+            return catalogItemId(val);
+        }
+        return self();
+    }
+
+
     public SpecT tag(Object tag) {
         tags.add(tag);
         return self();
@@ -187,7 +206,24 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     }
     
     public final String getCatalogItemId() {
-        return catalogItemId;
+        if (catalogItemIdStack.size() != 0) {
+            return catalogItemIdStack.getFirst();
+        }
+        return null;
+    }
+
+    /**
+     * Get immutable list of ids of this object's catalog item and its nested catalog items.
+     * e.g. if the catalog item is defined as
+     * <pre>
+     *     items:
+     *     - id: X
+     *       item: Y
+     * </pre>
+     * then the list will contain X, Y.
+     */
+    public final List<String> getNestedCatalogItemIds() {
+        return ImmutableList.copyOf(catalogItemIdStack);
     }
 
     public final Set<Object> getTags() {

--- a/api/src/main/java/org/apache/brooklyn/api/objs/BrooklynObject.java
+++ b/api/src/main/java/org/apache/brooklyn/api/objs/BrooklynObject.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.api.objs;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -57,6 +58,18 @@ public interface BrooklynObject extends Identifiable, Configurable {
      * Callers can set an explicit catalog item ID if inferencing is not correct.
      */
     String getCatalogItemId();
+
+    /**
+     * An immutable list of ids of this object's catalog item and its defining catalog items.
+     * e.g. if the catalog item is defined as
+     * <pre>
+     *     items:
+     *     - id: X
+     *       item: Y
+     * </pre>
+     * then the list will contain X, Y.
+     */
+    List<String> getCatalogItemSuperIds();
     
     /** 
      * Tags are arbitrary objects which can be attached to an entity for subsequent reference.

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampResolver.java
@@ -116,7 +116,7 @@ class CampResolver {
             throw new IllegalStateException("Creating spec from "+item+", got "+spec.getType()+" which is incompatible with expected "+expectedType);                
         }
 
-        spec.catalogItemIdIfNotNull(item.getId());
+        spec.nestCatalogItemId(item.getId());
 
         if (spec instanceof EntitySpec) {
             String name = spec.getDisplayName();

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigInheritanceYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigInheritanceYamlTest.java
@@ -36,6 +36,7 @@ import org.apache.brooklyn.core.entity.internal.EntityConfigMap;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -978,8 +978,8 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
         Entity app = createAndStartApplication(yaml);
         Entity entity = app.getChildren().iterator().next();
 
-        // Fails
-        assertEquals(entity.getCatalogItemId(), ver(symbolicNameInner));
+        assertEquals(entity.getCatalogItemId(), ver(symbolicNameOuter));
+        // TODO check nested ids
 
         deleteCatalogEntity(symbolicNameInner);
         deleteCatalogEntity(symbolicNameOuter);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -43,6 +43,7 @@ import org.apache.brooklyn.core.mgmt.osgi.OsgiStandaloneTest;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
@@ -976,10 +977,13 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
                 "  - serviceType: "+ver(symbolicNameOuter);
 
         Entity app = createAndStartApplication(yaml);
+
         Entity entity = app.getChildren().iterator().next();
 
         assertEquals(entity.getCatalogItemId(), ver(symbolicNameOuter));
-        // TODO check nested ids
+        assertEquals(entity.getCatalogItemSuperIds().size(), 2);
+        assertEquals(entity.getCatalogItemSuperIds().get(0), ver(symbolicNameOuter));
+        assertEquals(entity.getCatalogItemSuperIds().get(1), ver(symbolicNameInner));
 
         deleteCatalogEntity(symbolicNameInner);
         deleteCatalogEntity(symbolicNameOuter);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.brooklyn.camp.brooklyn.catalog;
 
+import static org.apache.brooklyn.util.osgi.OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_MESSAGE_RESOURCE;
+import static org.apache.commons.io.FileUtils.getFile;
+import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -39,11 +42,13 @@ import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.mgmt.osgi.OsgiStandaloneTest;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
@@ -51,6 +56,7 @@ import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.osgi.OsgiTestResources;
+import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -62,6 +68,8 @@ import com.google.common.collect.Iterables;
 public class CatalogYamlEntityTest extends AbstractYamlTest {
     
     private static final String SIMPLE_ENTITY_TYPE = OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_SIMPLE_ENTITY;
+    private static final String MORE_ENTITIES_POM_PROPERTIES_PATH =
+        "META-INF/maven/org.apache.brooklyn.test.resources.osgi/brooklyn-test-osgi-more-entities/pom.properties";
 
     @Override
     protected boolean disableOsgi() {
@@ -81,7 +89,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
 
         RegisteredType item = mgmt().getTypeRegistry().get(symbolicName, TEST_VERSION);
         String planYaml = RegisteredTypes.getImplementationDataStringForSpec(item);
-        assertTrue(planYaml.indexOf("services:")>=0, "expected 'services:' block: "+item+"\n"+planYaml);
+        assertTrue(planYaml.contains("services:"), "expected 'services:' block: "+item+"\n"+planYaml);
 
         deleteCatalogEntity(symbolicName);
     }
@@ -110,7 +118,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  name: My Catalog App",
             "  description: My description",
             "  icon_url: classpath://path/to/myicon.jpg",
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "  item: " + SIMPLE_ENTITY_TYPE);
 
@@ -133,7 +141,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  name: My Catalog App",
             "  description: My description",
             "  icon_url: classpath://path/to/myicon.jpg",
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "  item: " + SIMPLE_ENTITY_TYPE);
 
@@ -155,7 +163,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  description: My description",
             "  icon_url: classpath://path/to/myicon.jpg",
             "  version: " + TEST_VERSION,
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "",
             "services:",
@@ -177,7 +185,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "brooklyn.catalog:",
             "  name: " + id,
             "  itemType: entity",
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "  item:",
             "    type: "+ SIMPLE_ENTITY_TYPE);
@@ -196,7 +204,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "brooklyn.catalog:",
             "  name: " + id+":"+TEST_VERSION,
             "  itemType: entity",
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "services:",
             "- type: " + SIMPLE_ENTITY_TYPE);
@@ -242,7 +250,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
 
         RegisteredType referrer = mgmt().getTypeRegistry().get(referrerSymbolicName, TEST_VERSION);
         String planYaml = RegisteredTypes.getImplementationDataStringForSpec(referrer);
-        Assert.assertTrue(planYaml.indexOf("services")>=0, "expected services in: "+planYaml);
+        Assert.assertTrue(planYaml.contains("services"), "expected services in: "+planYaml);
         
         String yaml = "name: simple-app-yaml\n" +
                       "location: localhost\n" +
@@ -391,7 +399,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  id: " + firstItemId,
             "  version: " + TEST_VERSION,
             "  itemType: entity",
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "  item:",
             "    type: " + SIMPLE_ENTITY_TYPE);
@@ -402,7 +410,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  id: " + secondItemId,
             "  version: " + TEST_VERSION,
             "  itemType: entity",
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - name: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_NAME,
             "    version: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_VERSION,
             "  item:",
@@ -421,7 +429,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
                 "  id: my.catalog.app.id.non_existing.ref",
                 "  version: " + TEST_VERSION,
                 "  itemType: entity",
-                "  libraries:",
+                "  brooklyn.libraries:",
                 "  - name: " + nonExistentId,
                 "    version: " + nonExistentVersion,
                 "  item:",
@@ -440,7 +448,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
                 "  id: my.catalog.app.id.non_existing.ref",
                 "  version: " + TEST_VERSION,
                 "  itemType: entity",
-                "  libraries:",
+                "  brooklyn.libraries:",
                 "  - name: io.brooklyn.brooklyn-test-osgi-entities",
                 "  item:",
                 "    type: " + SIMPLE_ENTITY_TYPE);
@@ -454,7 +462,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
                 "  id: my.catalog.app.id.non_existing.ref",
                 "  version: " + TEST_VERSION,
                 "  itemType: entity",
-                "  libraries:",
+                "  brooklyn.libraries:",
                 "  - version: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_VERSION,
                 "  item:",
                 "    type: " + SIMPLE_ENTITY_TYPE);
@@ -474,7 +482,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  id: " + itemId,
             "  version: " + TEST_VERSION,
             "  itemType: entity",
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - name: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_NAME,
             "    version: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_VERSION,
             "    url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
@@ -500,7 +508,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
                 "  id: " + firstItemId,
                 "  version: " + TEST_VERSION,
                 "  itemType: entity",
-                "  libraries:",
+                "  brooklyn.libraries:",
                 "  - name: " + nonExistentId,
                 "    version: " + nonExistentVersion,
                 "    url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
@@ -904,7 +912,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  description: My description",
             "  icon_url: classpath://path/to/myicon.jpg",
             "  version: " + TEST_VERSION,
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "  item: " + SIMPLE_ENTITY_TYPE);
 
@@ -930,7 +938,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "    name: My Catalog App",
             "    description: My description",
             "    icon_url: classpath://path/to/myicon.jpg",
-            "    libraries:",
+            "    brooklyn.libraries:",
             "    - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "    item: " + SIMPLE_ENTITY_TYPE,
             "  - id: " + symbolicNameOuter,
@@ -948,11 +956,45 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
         deleteCatalogEntity(symbolicNameOuter);
     }
 
-    // The test is disabled as it fails. The entity will get assigned the outer-most catalog
-    // item which doesn't have the necessary libraries with visibility to the entity's classpath
-    // When loading resources from inside the entity then we will use the wrong BCLCS. A workaround
-    // has been implemented which explicitly adds the entity's class loader to the fallbacks.
-    @Test(groups="WIP")
+    @Test
+    public void testDeepCatalogItemCanLoadResources() throws Exception {
+        TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_PATH);
+
+        String symbolicNameInner = "my.catalog.app.id.inner";
+        String symbolicNameFiller = "my.catalog.app.id.filler";
+        String symbolicNameOuter = "my.catalog.app.id.outer";
+        addCatalogItems(
+            "brooklyn.catalog:",
+            "  version: " + TEST_VERSION,
+            "  items:",
+            "  - id: " + symbolicNameInner,
+            "    name: My Catalog App",
+            "    brooklyn.libraries:",
+            "    - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
+            "    item: " + SIMPLE_ENTITY_TYPE,
+            "  - id: " + symbolicNameFiller,
+            "    name: Filler App",
+            "    brooklyn.libraries:",
+            "    - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_MORE_ENTITIES_0_1_0_URL,
+            "    item: " + symbolicNameInner,
+            "  - id: " + symbolicNameOuter,
+            "    item: " + symbolicNameFiller);
+
+        String yaml = "name: " + symbolicNameOuter + "\n" +
+                "services: \n" +
+                "  - serviceType: "+ver(symbolicNameOuter);
+        Entity app = createAndStartApplication(yaml);
+        Entity entity = app.getChildren().iterator().next();
+
+        final String catalogBom = ResourceUtils.create(entity).getResourceAsString("classpath://" + MORE_ENTITIES_POM_PROPERTIES_PATH);
+        assertTrue(catalogBom.contains("artifactId=brooklyn-test-osgi-more-entities"));
+
+        deleteCatalogEntity(symbolicNameOuter);
+        deleteCatalogEntity(symbolicNameFiller);
+        deleteCatalogEntity(symbolicNameInner);
+    }
+
+    @Test
     public void testCatalogItemIdInReferencedItems() throws Exception {
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_PATH);
 
@@ -966,7 +1008,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "    name: My Catalog App",
             "    description: My description",
             "    icon_url: classpath://path/to/myicon.jpg",
-            "    libraries:",
+            "    brooklyn.libraries:",
             "    - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "    item: " + SIMPLE_ENTITY_TYPE,
             "  - id: " + symbolicNameOuter,
@@ -979,7 +1021,6 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
         Entity app = createAndStartApplication(yaml);
 
         Entity entity = app.getChildren().iterator().next();
-
         assertEquals(entity.getCatalogItemId(), ver(symbolicNameOuter));
         assertEquals(entity.getCatalogItemSuperIds().size(), 2);
         assertEquals(entity.getCatalogItemSuperIds().get(0), ver(symbolicNameOuter));
@@ -1020,7 +1061,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  name: My Catalog App",
             "  description: My description",
             "  icon_url: classpath://path/to/myicon.jpg",
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL +
             (extraLib ? "\n"+"  - url: "+OsgiStandaloneTest.BROOKLYN_OSGI_TEST_A_0_1_0_URL : ""),
             "  item:",
@@ -1034,7 +1075,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  description: My description",
             "  icon_url: classpath://path/to/myicon.jpg",
             "  version: " + TEST_VERSION,
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "  items:");
         
@@ -1057,7 +1098,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  name: My Catalog App",
             "  description: My description",
             "  icon_url: classpath://path/to/myicon.jpg",
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "  item:",
             "    services:",
@@ -1075,7 +1116,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             "  description: My description",
             "  icon_url: classpath://path/to/myicon.jpg",
             "  version: " + TEST_VERSION,
-            "  libraries:",
+            "  brooklyn.libraries:",
             "  - url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
             "  item:",
             "    type: " + BasicEntity.class.getName(),

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemDo.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemDo.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.core.catalog.internal;
 
 import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -128,6 +129,21 @@ public class CatalogItemDo<T,SpecT> implements CatalogItem<T,SpecT>, BrooklynObj
     @Override
     public void setCatalogItemId(String id) {
         itemDto.setCatalogItemId(id);
+    }
+
+    @Override
+    public void setCatalogItemIds(List<String> ids) {
+        itemDto.setCatalogItemIds(ids);
+    }
+
+    @Override
+    public List<String> getCatalogItemSuperIds() {
+        return itemDto.getCatalogItemSuperIds();
+    }
+
+    @Override
+    public void nestCatalogItemId(String id) {
+        itemDto.nestCatalogItemId(id);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemDtoAbstract.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemDtoAbstract.java
@@ -45,6 +45,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
+// TODO add support for nested catalog items, implement nestCatalogItemId in terms of symbolicName/Version
+// TODO also getCatalogItemSuperIds.
 public abstract class CatalogItemDtoAbstract<T, SpecT> extends AbstractBrooklynObject implements CatalogItem<T, SpecT> {
 
     private static Logger LOG = LoggerFactory.getLogger(CatalogItemDtoAbstract.class);

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
@@ -20,9 +20,11 @@ package org.apache.brooklyn.core.catalog.internal;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.ListIterator;
 
 import javax.annotation.Nullable;
 
+import com.google.common.collect.Lists;
 import org.apache.brooklyn.api.catalog.BrooklynCatalog;
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.catalog.CatalogItem.CatalogBundle;
@@ -189,7 +191,7 @@ public class CatalogUtils {
                 if (log.isDebugEnabled())
                     BrooklynLogging.log(log, BrooklynLogging.levelDebugOrTraceIfReadOnly(entity),
                         "Catalog item addition: "+entity+" from "+entity.getCatalogItemId()+" applying its catalog item ID to "+itemBeingAdded);
-                ((BrooklynObjectInternal)itemBeingAdded).setCatalogItemId(entity.getCatalogItemId());
+                ((BrooklynObjectInternal)itemBeingAdded).setCatalogItemIds(entity.getCatalogItemSuperIds());
             } else {
                 if (!itemBeingAdded.getCatalogItemId().equals(entity.getCatalogItemId())) {
                     // not a problem, but something to watch out for

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.core.catalog.internal;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 import javax.annotation.Nullable;
 
@@ -170,6 +171,13 @@ public class CatalogUtils {
     public static String getCatalogItemIdFromLoader(BrooklynClassLoadingContext loader) {
         if (loader instanceof OsgiBrooklynClassLoadingContext) {
             return ((OsgiBrooklynClassLoadingContext)loader).getCatalogItemId();
+        } else if (loader instanceof BrooklynClassLoadingContextSequential) {
+            final Iterator<BrooklynClassLoadingContext> iterator = ((BrooklynClassLoadingContextSequential) loader).getPrimaries().iterator();
+            if (iterator.hasNext()) {
+                BrooklynClassLoadingContext osgiLoader = iterator.next();
+                return getCatalogItemIdFromLoader(osgiLoader);
+            }
+            else return null;
         } else {
             return null;
         }

--- a/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManagerClient.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManagerClient.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.core.location.access;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
@@ -26,6 +27,7 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
+import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 
 import com.google.common.base.Preconditions;
@@ -384,6 +386,11 @@ public class PortForwardManagerClient implements PortForwardManager {
     @Override
     public String getCatalogItemId() {
         return getDelegate().getCatalogItemId();
+    }
+
+    @Override
+    public List<String> getCatalogItemSuperIds() {
+        return getDelegate().getCatalogItemSuperIds();
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
@@ -258,8 +258,7 @@ public class EntityManagementUtils {
         if (!wrapperParent.getParameters().isEmpty())
             wrappedChild.parametersReplace(wrapperParent.getParameters());
 
-        // prefer the wrapper ID (change in 2016-01); see notes on the catalogItemIdIfNotNull method
-        wrappedChild.catalogItemIdIfNotNull(wrapperParent.getCatalogItemId());
+        wrappedChild.nestCatalogItemId(wrapperParent.getCatalogItemId());
 
         // NB: this clobber's child config wherever they conflict; might prefer to deeply merge maps etc
         // (or maybe even prevent the merge in these cases; 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/BrooklynClassLoadingContextSequential.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/BrooklynClassLoadingContextSequential.java
@@ -38,7 +38,7 @@ import com.google.common.collect.Lists;
 public final class BrooklynClassLoadingContextSequential extends AbstractBrooklynClassLoadingContext {
 
     private static final Logger log = LoggerFactory.getLogger(BrooklynClassLoadingContextSequential.class);
-    
+
     private final List<BrooklynClassLoadingContext> primaries = MutableList.<BrooklynClassLoadingContext>of();
     // secondaries used to put java classloader last
     private final Set<BrooklynClassLoadingContext> secondaries = MutableSet.<BrooklynClassLoadingContext>of();
@@ -131,5 +131,8 @@ public final class BrooklynClassLoadingContextSequential extends AbstractBrookly
         if (!Objects.equal(secondaries, ((BrooklynClassLoadingContextSequential)obj).secondaries)) return false;
         return true;
     }
-    
+
+    public List<BrooklynClassLoadingContext> getPrimaries() {
+        return primaries;
+    }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
@@ -128,20 +128,18 @@ public abstract class AbstractManagementContext implements ManagementContextInte
             public BrooklynClassLoadingContext apply(@Nullable Object input) {
                 if (input instanceof EntityInternal) {
                     EntityInternal internal = (EntityInternal)input;
-                    if (internal.getCatalogItemId() != null) {
-                        RegisteredType item = internal.getManagementContext().getTypeRegistry().get(internal.getCatalogItemId());
-
-                        if (item != null) {
-                            BrooklynClassLoadingContext itemLoader = CatalogUtils.newClassLoadingContext(internal.getManagementContext(), item);
-                            // Falls back to the entity's class loader
-                            JavaBrooklynClassLoadingContext entityLoader = JavaBrooklynClassLoadingContext.create(input.getClass().getClassLoader());
-                            BrooklynClassLoadingContext seqLoader = new BrooklynClassLoadingContextSequential(internal.getManagementContext(), itemLoader, entityLoader);
-                            return seqLoader;
-                        } else {
-                            log.error("Can't find catalog item " + internal.getCatalogItemId() +
-                                    " used for instantiating entity " + internal +
-                                    ". Falling back to application classpath.");
+                    final List<String> catalogItemSuperIds = internal.getCatalogItemSuperIds();
+                    if (catalogItemSuperIds.size() > 0) {
+                        BrooklynClassLoadingContextSequential seqLoader = new BrooklynClassLoadingContextSequential(internal.getManagementContext());
+                        for (String catalogItemId : catalogItemSuperIds) {
+                            addCatalogItemContext(internal, seqLoader, catalogItemId);
                         }
+                        // TODO what if not all items were found? need to consider what the right behaviour is.
+                        // TODO for now take the course of using whatever items we *did* find
+                        if (seqLoader.getPrimaries().size() != catalogItemSuperIds.size()) {
+                            log.error("Couldn't find all catalog items  used for instantiating entity " + internal);
+                        }
+                        return seqLoader;
                     }
                     return apply(internal.getManagementSupport());
                 }
@@ -153,6 +151,19 @@ public abstract class AbstractManagementContext implements ManagementContextInte
                 return null;
             }
         });
+    }
+
+    private static void addCatalogItemContext(EntityInternal entity, BrooklynClassLoadingContextSequential loader, String catalogItemId) {
+        RegisteredType item = entity.getManagementContext().getTypeRegistry().get(catalogItemId);
+
+        if (item != null) {
+            BrooklynClassLoadingContext itemLoader = CatalogUtils.newClassLoadingContext(entity.getManagementContext(), item);
+            loader.add(itemLoader);
+        } else {
+            log.error("Can't find catalog item " + catalogItemId +
+                " used for instantiating entity " + entity +
+                ". Falling back to application classpath.");
+        }
     }
 
     private final AtomicLong totalEffectorInvocationCount = new AtomicLong();

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
@@ -917,6 +917,7 @@ public abstract class RebindIteration {
 
         protected void setCatalogItemId(BrooklynObject item, String catalogItemId) {
             if (catalogItemId!=null) {
+                // TODO add support for nested catalog superids here.
                 ((BrooklynObjectInternal)item).setCatalogItemId(catalogItemId);
             }
         }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -42,6 +42,7 @@ import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigMap;
+import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
@@ -423,7 +424,7 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
         this.entity = entity;
         this.execution = ((EntityInternal) entity).getExecutionContext();
         if (entity!=null && getCatalogItemId() == null) {
-            setCatalogItemId(entity.getCatalogItemId());
+            setCatalogItemIds(entity.getCatalogItemSuperIds());
         }
     }
     

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectInternal.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.objs;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.brooklyn.api.mgmt.rebind.RebindSupport;
@@ -34,6 +35,9 @@ import com.google.common.annotations.Beta;
 public interface BrooklynObjectInternal extends BrooklynObject, Rebindable {
     
     void setCatalogItemId(String id);
+    void setCatalogItemIds(List<String> id);
+
+    void nestCatalogItemId(String id);
     
     // subclasses typically apply stronger typing
     RebindSupport<?> getRebindSupport();

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.EntityTypeRegistry;
 import org.apache.brooklyn.api.entity.Group;
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.objs.SpecParameter;
 import org.apache.brooklyn.api.policy.Policy;
@@ -246,7 +247,7 @@ public class InternalEntityFactory extends InternalFactory {
                 ((AbstractEntity)entity).setDisplayName(spec.getDisplayName());
             
             if (spec.getCatalogItemId()!=null) {
-                ((AbstractEntity)entity).setCatalogItemId(spec.getCatalogItemId());
+                ((AbstractEntity)entity).setCatalogItemIds(spec.getCatalogItemSuperIds());
             }
             
             entity.tags().addTags(spec.getTags());
@@ -334,7 +335,7 @@ public class InternalEntityFactory extends InternalFactory {
                     // are already accessible through the REST API.
                     LocationSpec<?> taggedSpec = LocationSpec.create(locationSpec)
                             .tag(BrooklynTags.newOwnerEntityTag(entity.getId()));
-                    ((AbstractEntity)entity).addLocations(MutableList.of(
+                    ((AbstractEntity)entity).addLocations(MutableList.<Location>of(
                         managementContext.getLocationManager().createLocation(taggedSpec)));
                 }
                 ((AbstractEntity)entity).addLocations(spec.getLocations());

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalLocationFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalLocationFactory.java
@@ -118,7 +118,7 @@ public class InternalLocationFactory extends InternalFactory {
                 ((AbstractLocation)loc).setDisplayName(spec.getDisplayName());
             
             if (spec.getCatalogItemId()!=null) {
-                ((AbstractLocation)loc).setCatalogItemId(spec.getCatalogItemId());
+                ((AbstractLocation)loc).setCatalogItemIds(spec.getCatalogItemSuperIds());
             }
             
             loc.tags().addTags(spec.getTags());

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalPolicyFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalPolicyFactory.java
@@ -107,7 +107,7 @@ public class InternalPolicyFactory extends InternalFactory {
                 ((AbstractPolicy)pol).setDisplayName(spec.getDisplayName());
             }
             if (spec.getCatalogItemId()!=null) {
-                ((AbstractPolicy)pol).setCatalogItemId(spec.getCatalogItemId());
+                ((AbstractPolicy)pol).setCatalogItemIds(spec.getCatalogItemSuperIds());
             }
             
             pol.tags().addTags(spec.getTags());
@@ -148,7 +148,7 @@ public class InternalPolicyFactory extends InternalFactory {
                 ((AbstractEnricher)enricher).setDisplayName(spec.getDisplayName());
             
             if (spec.getCatalogItemId()!=null) {
-                ((AbstractEnricher)enricher).setCatalogItemId(spec.getCatalogItemId());
+                ((AbstractEnricher)enricher).setCatalogItemIds(spec.getCatalogItemSuperIds());
             }
             
             enricher.tags().addTags(spec.getTags());

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/AbstractTypePlanTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/AbstractTypePlanTransformer.java
@@ -104,7 +104,7 @@ public abstract class AbstractTypePlanTransformer implements BrooklynTypePlanTra
                     try { 
                         AbstractBrooklynObjectSpec<?, ?> result = createSpec(type, context);
                         // see notes on catalogItemIdIfNotNull
-                        result.catalogItemIdIfNotNull(type.getId());
+                        result.nestCatalogItemId(type.getId());
                         return result;
                     } catch (Exception e) { throw Exceptions.propagate(e); }
                 }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiStandaloneTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiStandaloneTest.java
@@ -49,7 +49,9 @@ public class OsgiStandaloneTest extends OsgiTestBase {
     public static final String BROOKLYN_OSGI_TEST_A_0_1_0_URL = "classpath:"+BROOKLYN_OSGI_TEST_A_0_1_0_PATH;
 
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_PATH = OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_PATH;
+    public static final String BROOKLYN_TEST_OSGI_MORE_ENTITIES_0_1_0_PATH = OsgiTestResources.BROOKLYN_TEST_OSGI_MORE_ENTITIES_0_1_0_PATH;
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_URL = "classpath:"+BROOKLYN_TEST_OSGI_ENTITIES_PATH;
+    public static final String BROOKLYN_TEST_OSGI_MORE_ENTITIES_0_1_0_URL = "classpath:"+BROOKLYN_TEST_OSGI_MORE_ENTITIES_0_1_0_PATH;
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_NAME = "org.apache.brooklyn.test.resources.osgi.brooklyn-test-osgi-entities";
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_VERSION = "0.1.0";
 

--- a/core/src/test/java/org/apache/brooklyn/util/core/ClassLoaderUtilsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/ClassLoaderUtilsTest.java
@@ -326,7 +326,7 @@ public class ClassLoaderUtilsTest {
                 .plan("{\"services\":[{\"type\": \"" + clazz.getName() + "\"}]}")
                 .build();
         mgmt.getCatalog().addItem(item);
-        ((EntityInternal)entity).setCatalogItemId(item.getId());
+        ((EntityInternal)entity).setCatalogItemIds(item.getCatalogItemSuperIds());
         return entity;
     }
 

--- a/utils/common/src/test/java/org/apache/brooklyn/util/osgi/OsgiTestResources.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/osgi/OsgiTestResources.java
@@ -41,6 +41,8 @@ public class OsgiTestResources {
      * defines an entity and an application, to confirm it can be read and used by brooklyn
      */
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_PATH = "/brooklyn/osgi/brooklyn-test-osgi-entities.jar";
+    public static final String BROOKLYN_TEST_OSGI_MORE_ENTITIES_0_1_0_PATH = "/brooklyn/osgi/brooklyn-test-osgi-more-entities_0.1.0.jar";
+    public static final String BROOKLYN_TEST_OSGI_ENTITIES_MESSAGE_RESOURCE = "/org/apache/brooklyn/test/osgi/resources/message.txt";
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_SIMPLE_APPLICATION = "org.apache.brooklyn.test.osgi.entities.SimpleApplication";
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_SIMPLE_ENTITY = "org.apache.brooklyn.test.osgi.entities.SimpleEntity";
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_SIMPLE_POLICY = "org.apache.brooklyn.test.osgi.entities.SimplePolicy";


### PR DESCRIPTION
For AMP-982, work in progress.

Updates BrooklynObject and BrooklynObjectSpec to support nested catalogItemIds.
### TODO:
- doesn't include changes to persistence to allow the nested item ids to be persisted and retrieved during rebind
- Need to review what changes may be needed to EntityTransientCopyInternal.
- Looks like catalogItemIdIfNotNull can be removed.
### Things to review

Everything, really; but some things I made a note of particularly
- review places where setCatalogItemIdIfNotNull has been replaced with nestCatalogItemIds and see if they make sense from a sanity viewpoint
- review use of setCatalogItemIds()
